### PR TITLE
ci: Surface Cloudflare Pages deployment status on PRs

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: docs
 
     environment:
-      name: ${{ github.event_name == 'pull_request' && 'preview' || 'stockindicators.dev' }}
+      name: ${{ github.ref == 'refs/heads/main' && 'stockindicators.dev' || 'preview' }}
       url: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
 
     steps:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
   packages: read
+  # `deployments`/`pull-requests` let wrangler-action record the Pages
+  # deployment and surface its preview URL on the PR.
+  deployments: write
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -27,7 +31,7 @@ jobs:
         working-directory: docs
 
     environment:
-      name: stockindicators.dev
+      name: ${{ github.event_name == 'pull_request' && 'preview' || 'stockindicators.dev' }}
       url: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
 
     steps:
@@ -79,6 +83,9 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Lets the action open a GitHub Deployment, so the preview URL and
+          # its status surface on the PR instead of only in the job log.
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           command: >
             pages deploy docs/.vitepress/dist
-            --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }}
+            --project-name=stock-indicators-dotnet


### PR DESCRIPTION
Aligns this repo's `wrangler-action` deploy with [facioquo/schemas `deploy.yml`](https://github.com/facioquo/schemas/blob/59569e0d7d1930cbd7b0da235c22d918410fe8a6/.github/workflows/deploy.yml) so PR-triggered Pages deploys report back to the PR.

**Why:** without `gitHubToken`, wrangler-action never calls `createDeployment`/`createDeploymentStatus`, so the preview URL only appears in the job log — no deployment entry, no status check on the PR.

### Changes
- `gitHubToken: ${{ secrets.GITHUB_TOKEN }}` on the wrangler-action step
- `deployments: write` + `pull-requests: write` added to workflow permissions
- Job `environment.name` now resolves to `preview` on PR runs, `stockindicators.dev` otherwise
- `--project-name` inlined as `stock-indicators-dotnet` (the existing Cloudflare project)

**On the project name:** it was only defined as a variable scoped to the `stockindicators.dev` environment, so routing PR runs to `preview` would have blanked `--project-name`. Inlining the existing value matches the schemas reference and avoids creating a new environment. Same Cloudflare project as before — no new project. The now-unused env-scoped `CLOUDFLARE_PROJECT_NAME` variable can be deleted after merge; it has no other references in this repo.

The preview build path (`ANALYTICS_ENABLED: false`) does not read the environment-scoped `GOOGLE_ANALYTICS_KEY`, so the environment switch does not affect it.