### PR TITLE
fix: Address code review findings in moved utility classes

### DIFF
--- a/src/Common/Math/DeMath.cs
+++ b/src/Common/Math/DeMath.cs
@@ -156,7 +156,7 @@ internal static class DeMath
             return double.NaN;
         }
 
-        if (x >= ExpOverflow)
+        if (x > ExpOverflow)
         {
             return double.PositiveInfinity;
         }
@@ -281,7 +281,7 @@ internal static class DeMath
 
         if (x == 0d)
         {
-            return 0d;
+            return x; // preserves signed zero
         }
 
         // Range reduction: atan(x) = sign(x) * (pi/2 - atan(1/|x|)) for |x| > 1
@@ -350,7 +350,13 @@ internal static class DeMath
             return -HalfPi;
         }
 
-        // Preserve signed-zero for (0,0) by returning `y` (will be +0.0 or -0.0)
+        // x == -0.0 belongs to the negative half-plane: (±0, -0) -> ±pi
+        if (BitConverter.DoubleToInt64Bits(x) < 0L)
+        {
+            return BitConverter.DoubleToInt64Bits(y) < 0L ? -Pi : Pi;
+        }
+
+        // Preserve signed-zero for (±0, +0) by returning `y` (will be +0.0 or -0.0)
         return y;
     }
 

--- a/src/Common/Math/DeMath.cs
+++ b/src/Common/Math/DeMath.cs
@@ -351,9 +351,9 @@ internal static class DeMath
         }
 
         // x == -0.0 belongs to the negative half-plane: (±0, -0) -> ±pi
-        if (BitConverter.DoubleToInt64Bits(x) < 0L)
+        if (double.IsNegative(x))
         {
-            return BitConverter.DoubleToInt64Bits(y) < 0L ? -Pi : Pi;
+            return double.IsNegative(y) ? -Pi : Pi;
         }
 
         // Preserve signed-zero for (±0, +0) by returning `y` (will be +0.0 or -0.0)

--- a/src/Common/Math/Numerical.cs
+++ b/src/Common/Math/Numerical.cs
@@ -8,7 +8,8 @@ namespace FacioQuo.Stock.Indicators;
 /// </summary>
 public static class Numerical
 {
-    private static readonly double[] LanczosCoefficients = [
+    private static ReadOnlySpan<double> LanczosCoefficients =>
+    [
         0.99999999999980993,
         676.5203681218851,
         -1259.1392167224028,
@@ -122,7 +123,7 @@ public static class Numerical
             return double.NaN;
         }
 
-        double[] c = LanczosCoefficients;
+        ReadOnlySpan<double> c = LanczosCoefficients;
 
         if (x < 0.5)
         {

--- a/src/Common/Math/Numerical.cs
+++ b/src/Common/Math/Numerical.cs
@@ -8,6 +8,18 @@ namespace FacioQuo.Stock.Indicators;
 /// </summary>
 public static class Numerical
 {
+    private static readonly double[] LanczosCoefficients = [
+        0.99999999999980993,
+        676.5203681218851,
+        -1259.1392167224028,
+        771.32342877765313,
+        -176.61502916214059,
+        12.507343278686905,
+        -0.13857109526572012,
+        9.9843695780195716e-6,
+        1.5056327351493116e-7
+    ];
+
     /// <summary>
     /// Calculates the standard deviation of an array of double values.
     /// </summary>
@@ -16,8 +28,7 @@ public static class Numerical
     /// <exception cref="ArgumentNullException">Thrown when the values array is null.</exception>
     public static double StdDev(this double[] values)
     {
-        ArgumentNullException.ThrowIfNull(
-            values, "StdDev values cannot be null.");
+        ArgumentNullException.ThrowIfNull(values);
 
         int n = values.Length;
 
@@ -50,19 +61,22 @@ public static class Numerical
     /// </summary>
     /// <param name="x">Array of x values.</param>
     /// <param name="y">Array of y values.</param>
-    /// <returns>Slope of the best fit line.</returns>
+    /// <returns>
+    /// Slope of the best fit line, or <see cref="double.NaN"/>
+    /// when the x values have zero variance.
+    /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when the x or y array is null.</exception>
     /// <exception cref="ArgumentException">Thrown when the x and y arrays are not the same size.</exception>
     public static double Slope(double[] x, double[] y)
     {
         // validate parameters
-        ArgumentNullException.ThrowIfNull(x, "Slope X values cannot be null.");
-        ArgumentNullException.ThrowIfNull(y, "Slope Y values cannot be null.");
+        ArgumentNullException.ThrowIfNull(x);
+        ArgumentNullException.ThrowIfNull(y);
 
         if (x.Length != y.Length)
         {
             throw new ArgumentException(
-                "Slope X and Y arrays must be the same size.");
+                "Slope X and Y arrays must be the same size.", nameof(y));
         }
 
         int length = x.Length;
@@ -93,7 +107,7 @@ public static class Numerical
             sumSqXy += devX * devY;
         }
 
-        return sumSqXy / sumSqX;
+        return sumSqX != 0 ? sumSqXy / sumSqX : double.NaN;
     }
 
     /// <summary>
@@ -108,17 +122,7 @@ public static class Numerical
             return double.NaN;
         }
 
-        double[] c = [
-            0.99999999999980993,
-            676.5203681218851,
-            -1259.1392167224028,
-            771.32342877765313,
-            -176.61502916214059,
-            12.507343278686905,
-            -0.13857109526572012,
-            9.9843695780195716e-6,
-            1.5056327351493116e-7
-        ];
+        double[] c = LanczosCoefficients;
 
         if (x < 0.5)
         {
@@ -189,13 +193,13 @@ public static class Numerical
         // source: https://stackoverflow.com/a/30205131/4496145
 
         n = Math.Abs(n); // make sure it is positive.
-        n -= (int)n;     // remove the integer part of the number.
+        n -= decimal.Truncate(n); // remove the integer part of the number.
         int decimalPlaces = 0;
         while (n > 0)
         {
             decimalPlaces++;
             n *= 10;
-            n -= (int)n;
+            n -= decimal.Truncate(n);
         }
 
         return decimalPlaces;

--- a/src/Common/Pruning/PruningList.cs
+++ b/src/Common/Pruning/PruningList.cs
@@ -221,19 +221,22 @@ internal sealed class PruningList<T> : IList<T>, IReadOnlyList<T>
     }
 
     /// <inheritdoc/>
-    public IEnumerator<T> GetEnumerator()
-    {
-        int version = _version;
-        int end = _items.Count;
+    public IEnumerator<T> GetEnumerator() => Enumerate(_version, Count);
 
-        for (int i = _head; i < end; i++)
+    // Captures _version and Count eagerly (at GetEnumerator time, not first
+    // MoveNext) and iterates logical indexes so that prefix reclamation,
+    // which shifts _items and resets _head without a version bump, cannot
+    // skip or repeat elements under an active enumerator.
+    private IEnumerator<T> Enumerate(int version, int count)
+    {
+        for (int index = 0; index < count; index++)
         {
             if (version != _version)
             {
                 throw new InvalidOperationException(ModifiedDuringEnumeration);
             }
 
-            yield return _items[i];
+            yield return _items[_head + index];
         }
 
         if (version != _version)

--- a/src/Common/StreamHub/BinarySettings.cs
+++ b/src/Common/StreamHub/BinarySettings.cs
@@ -64,10 +64,16 @@ public readonly struct BinarySettings(
     /// <summary>
     /// Gets the value of the bit at the specified index.
     /// </summary>
-    /// <param name="index">Index of the bit to get.</param>
+    /// <param name="index">Index of the bit to get, from 0 to 7.</param>
     /// <returns>True if the bit is set; otherwise, false.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when the index is outside the range of 0 to 7.
+    /// </exception>
     public bool this[short index]
-        => (Settings & (1 << index)) != 0;
+        => index is >= 0 and <= 7
+            ? (Settings & (1 << index)) != 0
+            : throw new ArgumentOutOfRangeException(
+                nameof(index), index, "Bit index must be between 0 and 7.");
 
     /// <summary>
     /// Combines the current settings with another <see cref="BinarySettings"/> instance

--- a/src/Indicators/a-b/BarPart/BarPartHub.cs
+++ b/src/Indicators/a-b/BarPart/BarPartHub.cs
@@ -65,7 +65,7 @@ public static partial class BarParts
     /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
     /// <returns>An new <see cref="BarPartHub"/> instance.</returns>
     /// <exception cref="ArgumentNullException">Thrown when the bar provider is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="candlePart"/> is invalid.</exception>
     public static BarPartHub ToBarPartHub(
         this IBarProvider<IBar> barProvider,
         CandlePart candlePart)

--- a/src/Indicators/a-b/BarPart/BarPartHub.cs
+++ b/src/Indicators/a-b/BarPart/BarPartHub.cs
@@ -11,7 +11,7 @@ public class BarPartHub
         CandlePart candlePart
     ) : base(provider)
     {
-        CandlePartSelection = candlePart;
+        CandlePartSelection = BarParts.Validate(candlePart);
 
         Reinitialize();
     }

--- a/src/Indicators/a-b/BarPart/BarPartList.cs
+++ b/src/Indicators/a-b/BarPart/BarPartList.cs
@@ -4,7 +4,7 @@ namespace FacioQuo.Stock.Indicators;
 /// Bar part selection from incremental bars.
 /// </summary>
 /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
-/// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
+/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="candlePart"/> is invalid.</exception>
 public class BarPartList(CandlePart candlePart) : BufferList<TimeValue>, IIncrementFromBar, IBarPart
 {
     /// <summary>
@@ -12,8 +12,8 @@ public class BarPartList(CandlePart candlePart) : BufferList<TimeValue>, IIncrem
     /// </summary>
     /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
     /// <param name="bars">Aggregate OHLCV price bars, time sorted.</param>
-    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="bars"/> list is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="bars"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="candlePart"/> is invalid.</exception>
     public BarPartList(CandlePart candlePart, IReadOnlyList<IBar> bars)
         : this(candlePart) => Add(bars);
 
@@ -58,8 +58,8 @@ public static partial class BarParts
     /// </summary>
     /// <param name="bars">Aggregate OHLCV price bars, time sorted.</param>
     /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
-    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="bars"/> list is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="bars"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="candlePart"/> is invalid.</exception>
     public static BarPartList ToBarPartList(
         this IReadOnlyList<IBar> bars,
         CandlePart candlePart)

--- a/src/Indicators/a-b/BarPart/BarPartList.cs
+++ b/src/Indicators/a-b/BarPart/BarPartList.cs
@@ -4,6 +4,7 @@ namespace FacioQuo.Stock.Indicators;
 /// Bar part selection from incremental bars.
 /// </summary>
 /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
+/// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
 public class BarPartList(CandlePart candlePart) : BufferList<TimeValue>, IIncrementFromBar, IBarPart
 {
     /// <summary>
@@ -11,11 +12,18 @@ public class BarPartList(CandlePart candlePart) : BufferList<TimeValue>, IIncrem
     /// </summary>
     /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
     /// <param name="bars">Aggregate OHLCV price bars, time sorted.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="bars"/> list is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
     public BarPartList(CandlePart candlePart, IReadOnlyList<IBar> bars)
         : this(candlePart) => Add(bars);
 
     /// <inheritdoc />
-    public CandlePart CandlePartSelection { get; init; } = candlePart;
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the assigned value is invalid.</exception>
+    public CandlePart CandlePartSelection
+    {
+        get;
+        init => field = BarParts.Validate(value);
+    } = BarParts.Validate(candlePart);
 
     /// <inheritdoc />
     public void Add(IBar bar)
@@ -50,6 +58,8 @@ public static partial class BarParts
     /// </summary>
     /// <param name="bars">Aggregate OHLCV price bars, time sorted.</param>
     /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="bars"/> list is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
     public static BarPartList ToBarPartList(
         this IReadOnlyList<IBar> bars,
         CandlePart candlePart)

--- a/src/Indicators/a-b/BarPart/BarParts.Series.cs
+++ b/src/Indicators/a-b/BarPart/BarParts.Series.cs
@@ -15,8 +15,8 @@ public static partial class BarParts
     /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
     /// <returns>List of <see cref="TimeValue"/> records.</returns>
     /// <remarks>Also available via the <see cref="Use(IReadOnlyList{IBar}, CandlePart)"/> alias.</remarks>
-    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="bars"/> list is null.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="bars"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="candlePart"/> is invalid.</exception>
     public static IReadOnlyList<TimeValue> ToBarPart(
         this IReadOnlyList<IBar> bars,
         CandlePart candlePart)

--- a/src/Indicators/a-b/BarPart/BarParts.Series.cs
+++ b/src/Indicators/a-b/BarPart/BarParts.Series.cs
@@ -15,11 +15,15 @@ public static partial class BarParts
     /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
     /// <returns>List of <see cref="TimeValue"/> records.</returns>
     /// <remarks>Also available via the <see cref="Use(IReadOnlyList{IBar}, CandlePart)"/> alias.</remarks>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="bars"/> list is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="candlePart"/> invalid.</exception>
     public static IReadOnlyList<TimeValue> ToBarPart(
         this IReadOnlyList<IBar> bars,
         CandlePart candlePart)
     {
         ArgumentNullException.ThrowIfNull(bars);
+        Validate(candlePart);
+
         int length = bars.Count;
         List<TimeValue> result = new(length);
 

--- a/src/Indicators/a-b/BarPart/BarParts.Utilities.cs
+++ b/src/Indicators/a-b/BarPart/BarParts.Utilities.cs
@@ -5,6 +5,18 @@ namespace FacioQuo.Stock.Indicators;
 public static partial class BarParts
 {
     /// <summary>
+    /// validate the CandlePart selection
+    /// </summary>
+    /// <param name="candlePart">The <see cref="CandlePart" /> element.</param>
+    /// <returns>The validated <paramref name="candlePart"/> value.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a parameter is out of the valid range</exception>
+    internal static CandlePart Validate(CandlePart candlePart)
+        => Enum.IsDefined(candlePart)
+            ? candlePart
+            : throw new ArgumentOutOfRangeException(
+                nameof(candlePart), candlePart, "Invalid candlePart provided.");
+
+    /// <summary>
     /// convert TBar element to a basic <see cref="TimeValue"/> class
     /// </summary>
     /// <param name="q">Bar to convert</param>

--- a/tests/Library/Common/Math/DeMath.Tests.cs
+++ b/tests/Library/Common/Math/DeMath.Tests.cs
@@ -1,0 +1,51 @@
+namespace Utilities;
+
+[TestClass]
+[TestCategory("Utilities")]
+public class DeMaths : TestBase
+{
+    [TestMethod]
+    public void Atan_SignedZero_PreservesSign()
+    {
+        double positive = DeMath.Atan(0.0);
+        double negative = DeMath.Atan(-0.0);
+
+        double.IsNegative(positive).Should().BeFalse();
+        double.IsNegative(negative).Should().BeTrue();
+        positive.Should().Be(0.0);
+        negative.Should().Be(-0.0);
+    }
+
+    [TestMethod]
+    public void Atan2_SignedZeroInputs_MatchesMathAtan2()
+    {
+        // negative-zero x belongs to the negative half-plane
+        DeMath.Atan2(0.0, -0.0).Should().Be(Math.Atan2(0.0, -0.0));   // +pi
+        DeMath.Atan2(-0.0, -0.0).Should().Be(Math.Atan2(-0.0, -0.0)); // -pi
+
+        // positive-zero x preserves the sign of y
+        double posY = DeMath.Atan2(0.0, 0.0);
+        double negY = DeMath.Atan2(-0.0, 0.0);
+        double.IsNegative(posY).Should().BeFalse();
+        double.IsNegative(negY).Should().BeTrue();
+
+        // y = -0.0 with positive x preserves the sign of y
+        double.IsNegative(DeMath.Atan2(-0.0, 1.0)).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Exp_AtOverflowBoundary_ReturnsFiniteValue()
+    {
+        // ln(double.MaxValue): exp is finite exactly at
+        // this value and overflows just above it; the
+        // literal is the correctly-rounded exp(boundary),
+        // deterministic across platforms unlike Math.Exp
+        const double boundary = 709.782712893383973096d;
+
+        DeMath.Exp(boundary).Should().Be(1.7976931348622732E+308);
+        double.IsFinite(DeMath.Exp(boundary)).Should().BeTrue();
+
+        double aboveBoundary = Math.BitIncrement(boundary);
+        DeMath.Exp(aboveBoundary).Should().Be(double.PositiveInfinity);
+    }
+}

--- a/tests/Library/Common/Math/Numerical.Tests.cs
+++ b/tests/Library/Common/Math/Numerical.Tests.cs
@@ -62,7 +62,7 @@ public class Numericals : TestBase
     [TestMethod]
     public void Slope_AllEqualXValues_ReturnsNaN()
     {
-        // pins IEEE 754 0/0 = NaN for zero-variance x
+        // regression: zero-variance x yields NaN (0/0 per IEEE 754)
         double[] flatX = [5, 5, 5, 5];
         double[] anyY = [1, 2, 3, 4];
 

--- a/tests/Library/Common/Math/Numerical.Tests.cs
+++ b/tests/Library/Common/Math/Numerical.Tests.cs
@@ -24,7 +24,8 @@ public class Numericals : TestBase
         => FluentActions
             .Invoking(static () => Numerical.StdDev(null))
             .Should()
-            .ThrowExactly<ArgumentNullException>();
+            .ThrowExactly<ArgumentNullException>()
+            .WithParameterName("values");
 
     [TestMethod]
     public void Slope()
@@ -39,21 +40,24 @@ public class Numericals : TestBase
         => FluentActions
             .Invoking(() => Numerical.Slope(null, _x))
             .Should()
-            .ThrowExactly<ArgumentNullException>();
+            .ThrowExactly<ArgumentNullException>()
+            .WithParameterName("x");
 
     [TestMethod]
     public void SlopeYnull()
         => FluentActions
             .Invoking(() => Numerical.Slope(_x, null))
             .Should()
-            .ThrowExactly<ArgumentNullException>();
+            .ThrowExactly<ArgumentNullException>()
+            .WithParameterName("y");
 
     [TestMethod]
     public void SlopeMismatch()
         => FluentActions
             .Invoking(() => Numerical.Slope(_x, _y))
             .Should()
-            .ThrowExactly<ArgumentException>();
+            .ThrowExactly<ArgumentException>()
+            .WithParameterName("y");
 
     [TestMethod]
     public void Slope_AllEqualXValues_ReturnsNaN()

--- a/tests/Library/Common/Math/Numerical.Tests.cs
+++ b/tests/Library/Common/Math/Numerical.Tests.cs
@@ -56,6 +56,44 @@ public class Numericals : TestBase
             .ThrowExactly<ArgumentException>();
 
     [TestMethod]
+    public void Slope_AllEqualXValues_ReturnsNaN()
+    {
+        // pins IEEE 754 0/0 = NaN for zero-variance x
+        double[] flatX = [5, 5, 5, 5];
+        double[] anyY = [1, 2, 3, 4];
+
+        double s = Numerical.Slope(flatX, anyY);
+
+        s.Should().Be(double.NaN);
+    }
+
+    [TestMethod]
+    public void Slope_SquaredDeviationUnderflow_ReturnsNaN()
+    {
+        // devX * devX underflows to exactly 0 while devX * devY
+        // does not; without the zero-denominator guard this
+        // returned +Infinity instead of NaN
+        double[] tinyX = [1e-200, -1e-200];
+        double[] hugeY = [1e200, -1e200];
+
+        double s = Numerical.Slope(tinyX, hugeY);
+
+        s.Should().Be(double.NaN);
+    }
+
+    [TestMethod]
+    public void GetDecimalPlaces_LargeIntegerPart_DoesNotOverflow()
+    {
+        // values beyond int.MaxValue (e.g. large volumes)
+        // previously threw OverflowException from an int cast
+        const decimal largeVolume = 3_000_000_000.25m;
+
+        int places = largeVolume.GetDecimalPlaces();
+
+        places.Should().Be(2);
+    }
+
+    [TestMethod]
     public void RoundDownDate()
     {
         TimeSpan interval = BarInterval.OneHour.ToTimeSpan();

--- a/tests/Library/Common/Pruning/PruningList.Tests.cs
+++ b/tests/Library/Common/Pruning/PruningList.Tests.cs
@@ -221,6 +221,56 @@ public class PruningListTests : TestBase
     }
 
     [TestMethod]
+    public void Enumerate_AcrossNoOpRemoveAllWithActiveHead_YieldsCorrectItems()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 4; i++)
+        {
+            sut.Add(i);
+        }
+
+        // advance the head so a dead prefix exists
+        sut.RemoveAt(0);
+
+        // a no-match RemoveAll reclaims the dead prefix
+        // without a version bump; enumeration must still
+        // yield the correct remaining elements
+        using IEnumerator<int> enumerator = sut.GetEnumerator();
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be(1);
+
+        int removed = sut.RemoveAll(static _ => false);
+        removed.Should().Be(0);
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be(2);
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be(3);
+        enumerator.MoveNext().Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Enumerate_ModifiedBeforeFirstMoveNext_Throws()
+    {
+        PruningList<int> sut = [];
+
+        for (int i = 0; i < 3; i++)
+        {
+            sut.Add(i);
+        }
+
+        // version must be captured at GetEnumerator time,
+        // not deferred to the first MoveNext
+        using IEnumerator<int> enumerator = sut.GetEnumerator();
+        sut.Add(100);
+
+        Action act = () => enumerator.MoveNext();
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [TestMethod]
     public void AsReadOnly_ReflectsLiveWindowAndIsImmutable()
     {
         PruningList<int> sut = [];

--- a/tests/Library/Common/StreamHub/BinarySettingsTests.cs
+++ b/tests/Library/Common/StreamHub/BinarySettingsTests.cs
@@ -6,7 +6,7 @@ public class BinarySettingsTests : TestBase
     // see Renko Hub tests for inheritance
 
     [TestMethod]
-    public void InitializationDefault()
+    public void Ctor_Default_SetsZeroSettingsAndFullMask()
     {
         BinarySettings sut = new();
         sut.Settings.Should().Be(0);
@@ -14,7 +14,7 @@ public class BinarySettingsTests : TestBase
     }
 
     [TestMethod]
-    public void InitializationPartial()
+    public void Ctor_WithSettingsOnly_UsesDefaultMask()
     {
         BinarySettings sut = new(0);
         sut.Settings.Should().Be(0);
@@ -22,7 +22,7 @@ public class BinarySettingsTests : TestBase
     }
 
     [TestMethod]
-    public void InitializationCustom()
+    public void Ctor_WithSettingsAndMask_SetsBoth()
     {
         BinarySettings sut = new(0b10101010, 0b11001100);
         sut.Settings.Should().Be(0b10101010);
@@ -30,7 +30,7 @@ public class BinarySettingsTests : TestBase
     }
 
     [TestMethod]
-    public void AccessBit()
+    public void Indexer_WithBitPosition_ReturnsExpectedBit()
     {
         BinarySettings sut = new(0b00010001);
 
@@ -46,7 +46,23 @@ public class BinarySettingsTests : TestBase
     }
 
     [TestMethod]
-    public void CombineDefaultMask()
+    public void Indexer_OutOfRangeIndex_Throws()
+    {
+        BinarySettings sut = new(0b00000001);
+
+        // without range validation, shift wraparound
+        // would silently read bit 0 for index 32
+        Action negative = () => _ = sut[-1];
+        Action tooHigh = () => _ = sut[8];
+        Action wrapped = () => _ = sut[32];
+
+        negative.Should().Throw<ArgumentOutOfRangeException>();
+        tooHigh.Should().Throw<ArgumentOutOfRangeException>();
+        wrapped.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void Combine_WithDefaultMask_MergesSettings()
     {
         BinarySettings srcSettings = new(0b01101001);
         BinarySettings defSettings = new(0b00000010);
@@ -55,7 +71,7 @@ public class BinarySettingsTests : TestBase
     }
 
     [TestMethod]
-    public void CombineCustomMask()
+    public void Combine_WithCustomMask_ExcludesMaskedBits()
     {
         BinarySettings srcSettings = new(0b01101001, 0b11111110);
         BinarySettings defSettings = new(0b00000010);
@@ -64,31 +80,31 @@ public class BinarySettingsTests : TestBase
     }
 
     [TestMethod]
-    public void Equality()
+    public void Equality_WithSameAndDifferentValues_ComparesCorrectly()
     {
         BinarySettings sut = new();
-        Assert.AreEqual(0b00000000, sut.Settings);
-        Assert.AreEqual(0b11111111, sut.Mask);
+        sut.Settings.Should().Be(0b00000000);
+        sut.Mask.Should().Be(0b11111111);
 
         object obj = new BinarySettings(0b01100010);
         BinarySettings sutA = new(0b01100010);
         BinarySettings sutB = new(0b01100010);
         BinarySettings sutC = new(0b01101010); // different
 
-        Assert.AreEqual(sutA, sutB);
+        sutA.Should().Be(sutB);
 
-        // object equality
-        Assert.IsTrue(obj.Equals(sutA));
-        Assert.IsTrue(sutA.Equals(obj));
+        // object equality, Equals(object) dispatch
+        obj.Equals(sutA).Should().BeTrue();
+        sutA.Equals(obj).Should().BeTrue();
 
-        // struct equality
-        Assert.IsTrue(sutA.Equals(sutB));
-        Assert.IsTrue(sutB.Equals(sutA));
-        Assert.IsFalse(sutB.Equals(sutC));
+        // struct equality, Equals(BinarySettings) overload
+        sutA.Equals(sutB).Should().BeTrue();
+        sutB.Equals(sutA).Should().BeTrue();
+        sutB.Equals(sutC).Should().BeFalse();
 
-        // operator equality
-        Assert.IsTrue(sutA == sutB);
-        Assert.IsFalse(sutA == sutC);
-        Assert.IsTrue(sutB != sutC);
+        // custom operator equality
+        (sutA == sutB).Should().BeTrue();
+        (sutA == sutC).Should().BeFalse();
+        (sutB != sutC).Should().BeTrue();
     }
 }

--- a/tests/Library/Indicators/a-b/BarPart/BarPartBufferListTests.cs
+++ b/tests/Library/Indicators/a-b/BarPart/BarPartBufferListTests.cs
@@ -89,6 +89,22 @@ public class BarPartBufferListTests : BufferListTestBase, ITestBarBufferList
     }
 
     [TestMethod]
+    public void BarsCtor_InvalidCandlePart_Throws()
+    {
+        Action act = () => _ = new BarPartList((CandlePart)99, Bars);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void ToBarPartList_InvalidCandlePart_Throws()
+    {
+        Action act = () => _ = Bars.ToBarPartList((CandlePart)99);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
     public void InitAccessor_InvalidCandlePart_Throws()
     {
         // object initializers bypass the constructor argument,

--- a/tests/Library/Indicators/a-b/BarPart/BarPartBufferListTests.cs
+++ b/tests/Library/Indicators/a-b/BarPart/BarPartBufferListTests.cs
@@ -81,7 +81,27 @@ public class BarPartBufferListTests : BufferListTestBase, ITestBarBufferList
     }
 
     [TestMethod]
-    public void MultipleCandleParts()
+    public void Ctor_InvalidCandlePart_Throws()
+    {
+        Action act = () => _ = new BarPartList((CandlePart)99);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void InitAccessor_InvalidCandlePart_Throws()
+    {
+        // object initializers bypass the constructor argument,
+        // so the init accessor must validate too
+        Action act = () => _ = new BarPartList(CandlePart.Close) {
+            CandlePartSelection = (CandlePart)99
+        };
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void BarsCtor_WithVariousCandleParts_MatchesSeries()
     {
         // Test different candle parts
         IReadOnlyList<TimeValue> openSeries = Bars.ToBarPart(CandlePart.Open);

--- a/tests/Library/Indicators/a-b/BarPart/BarPartCatalogTests.cs
+++ b/tests/Library/Indicators/a-b/BarPart/BarPartCatalogTests.cs
@@ -7,7 +7,7 @@ namespace Catalogging;
 public class BarPartCatalogTests : TestBase
 {
     [TestMethod]
-    public void BarPartSeriesListing()
+    public void BarPartSeries_InCatalog_ExecutesAndMatchesDirectCall()
     {
         // Arrange
         IReadOnlyList<Bar> bars = Bars;
@@ -41,7 +41,7 @@ public class BarPartCatalogTests : TestBase
     }
 
     [TestMethod]
-    public void BarPartStreamListing()
+    public void BarPartStream_InCatalog_HasExpectedMetadata()
     {
         // Act
         IndicatorListing listing = BarParts.StreamListing;
@@ -52,6 +52,7 @@ public class BarPartCatalogTests : TestBase
         listing.Uiid.Should().Be("BARPART");
         listing.Style.Should().Be(Style.Stream);
         listing.Category.Should().Be(Category.PriceTransform);
+        listing.MethodName.Should().Be("ToBarPartHub");
 
         listing.Parameters.Should().NotBeNull();
         listing.Parameters.Should().HaveCount(1);
@@ -71,7 +72,7 @@ public class BarPartCatalogTests : TestBase
     }
 
     [TestMethod]
-    public void BarPartBufferListing()
+    public void BarPartBuffer_InCatalog_HasExpectedMetadata()
     {
         // Act
         IndicatorListing listing = BarParts.BufferListing;
@@ -82,6 +83,7 @@ public class BarPartCatalogTests : TestBase
         listing.Uiid.Should().Be("BARPART");
         listing.Style.Should().Be(Style.Buffer);
         listing.Category.Should().Be(Category.PriceTransform);
+        listing.MethodName.Should().Be("ToBarPartList");
 
         listing.Parameters.Should().NotBeNull();
         listing.Parameters.Should().HaveCount(1);
@@ -101,7 +103,7 @@ public class BarPartCatalogTests : TestBase
     }
 
     [TestMethod]
-    public void CatalogBrowsingIncludesBarPartSeries()
+    public void CatalogBrowsing_WithBarPartSeries_IncludesBarPartSeries()
     {
         // Act
         IReadOnlyList<IndicatorListing> catalog = Catalog.Get();

--- a/tests/Library/Indicators/a-b/BarPart/BarPartHubTests.cs
+++ b/tests/Library/Indicators/a-b/BarPart/BarPartHubTests.cs
@@ -136,4 +136,16 @@ public class BarPartHubTests : StreamHubTestBase, ITestBarObserver, ITestChainPr
         BarPartHub hub = new(new BarHub(), CandlePart.Close);
         hub.ToString().Should().Be("BAR-PART(CLOSE)");
     }
+
+    [TestMethod]
+    public void Ctor_InvalidCandlePart_Throws()
+    {
+        BarHub barHub = new();
+
+        Action act = () => _ = barHub.ToBarPartHub((CandlePart)99);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+
+        barHub.EndTransmission();
+    }
 }

--- a/tests/Library/Indicators/a-b/BarPart/BarPartSeriesTests.cs
+++ b/tests/Library/Indicators/a-b/BarPart/BarPartSeriesTests.cs
@@ -73,6 +73,16 @@ public class BarPartSeriesTests : StaticSeriesTestBase
     }
 
     [TestMethod]
+    public void ToBarPart_InvalidCandlePart_ThrowsEvenWhenEmpty()
+    {
+        Action withBars = () => _ = Bars.ToBarPart((CandlePart)99);
+        Action withEmpty = () => _ = Nobars.ToBarPart((CandlePart)99);
+
+        withBars.Should().Throw<ArgumentOutOfRangeException>();
+        withEmpty.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
     public override void NoBars_ReturnsEmpty()
     {
         IReadOnlyList<TimeValue> r0 = Nobars

--- a/tests/Library/Indicators/a-b/BarPart/BarParts.Utilities.Tests.cs
+++ b/tests/Library/Indicators/a-b/BarPart/BarParts.Utilities.Tests.cs
@@ -1,10 +1,10 @@
 namespace Utilities;
 
 [TestClass]
-public class BarPartBufferListTests : TestBaseWithPrecision
+public class BarPartUtilitiesTests : TestBaseWithPrecision
 {
     [TestMethod]
-    public void ConvertBar()
+    public void ToBarPart_SingleBar_ConvertsAllCandleParts()
     {
         // compose basic data
         TimeValue o = Bars[501].ToBarPart(CandlePart.Open);
@@ -37,7 +37,7 @@ public class BarPartBufferListTests : TestBaseWithPrecision
     }
 
     [TestMethod]
-    public void ConvertList()
+    public void ToBarPart_BarList_ConvertsAllCandleParts()
     {
         // compose data
         IReadOnlyList<TimeValue> o = Bars.ToBarPart(CandlePart.Open);


### PR DESCRIPTION
Behavioral and quality fixes for pre-existing issues surfaced by review of the file reorganization (all baseline-safe; no indicator numerical outputs change):

- **Numerical**: correct `ArgumentNullException.ThrowIfNull` calls that passed messages as paramName (pinned by `WithParameterName` assertions); add paramName to Slope length mismatch; guard Slope zero denominator per NaN policy (documented `NaN` return); replace int casts in `GetDecimalPlaces` with `decimal.Truncate` to fix `OverflowException` on volumes above `int.MaxValue`; hoist Lanczos coefficients to a static field
- **DeMath**: preserve signed zero in `Atan` and `Atan2` (matching the documented `Math.Atan2` quadrant contract); return finite result at the exact `Exp` overflow boundary (test asserts the deterministic correctly-rounded literal, not platform `Math.Exp`)
- **PruningList**: capture version and count at `GetEnumerator` time and iterate logical indexes so prefix reclamation from a no-match `RemoveAll` cannot skip elements under an active enumerator
- **BinarySettings**: validate indexer range (0–7) instead of silently wrapping shift counts
- **BarPart**: centralize `CandlePart` validation — hubs, buffer lists, and series conversions reject undefined values eagerly, including via the `BarPartList.CandlePartSelection` `init` accessor (object-initializer path); `<exception>` docs added in house style on all public entry points
- **Tests**: cover all fixes with discriminating tests (each fails on pre-fix code); assert catalog `MethodName` for stream and buffer listings; align test names with the `MethodName_StateUnderTest_ExpectedBehavior` convention; preserve operator and `Equals(object)` dispatch coverage in `BinarySettings` equality tests; rename duplicate `BarPartBufferListTests` class in utilities tests to `BarPartUtilitiesTests`