### PR TITLE
refactor: Rename OutType members to Csv and Json

### DIFF
--- a/src/Common/StringFormatters/OutType.cs
+++ b/src/Common/StringFormatters/OutType.cs
@@ -13,10 +13,10 @@ public enum OutType
     /// <summary>
     /// Comma-separated values format.
     /// </summary>
-    CSV = 1,
+    Csv = 1,
 
     /// <summary>
     /// JSON format.
     /// </summary>
-    JSON = 2
+    Json = 2
 }


### PR DESCRIPTION
Aligns the OutType enum with .NET capitalization conventions for
acronyms longer than two letters (CSV -> Csv, JSON -> Json).

BREAKING CHANGE: source-breaking for consumers referencing
OutType.CSV or OutType.JSON; numeric values are unchanged. The
enum has no internal references, so no call sites change.
Obsolete-alias shims were considered but rejected: duplicate
members differing only by case trigger CA1708.

+semver: major

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>