### PR TITLE
ci: Stop double-deploying website previews

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -9,10 +9,6 @@ on:
 permissions:
   contents: read
   packages: read
-  # `deployments`/`pull-requests` let wrangler-action record the Pages
-  # deployment and surface its preview URL on the PR.
-  deployments: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -83,9 +79,12 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Lets the action open a GitHub Deployment, so the preview URL and
-          # its status surface on the PR instead of only in the job log.
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          # Do not pass `gitHubToken`: it makes wrangler-action open a second
+          # GitHub Deployment on top of the one the job `environment` already
+          # records, which shows up as a duplicate deployment on the PR.
+          # `--branch` is explicit because `pull_request` checkouts are on a
+          # detached HEAD, which would otherwise alias every PR to `head.`.
           command: >
             pages deploy docs/.vitepress/dist
             --project-name=stock-indicators-dotnet
+            --branch=${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - docs/**
+      - .github/workflows/deploy-website.yml
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #2177

## Root cause

#2168 added `gitHubToken` to the `cloudflare/wrangler-action` step. That input does exactly one thing: it makes the action call `createGitHubDeployment` itself. The job already declares an `environment:`, which makes Actions record a deployment on its own — so every push to a docs PR produced **two** GitHub Deployments for the `preview` environment.

Confirmed via the deployments API — two records per SHA, ~1 min apart:

| Creator | Description | URL | States |
| --- | --- | --- | --- |
| PR actor | `null` | `https://head.…pages.dev` | in_progress → success → inactive |
| `github-actions[bot]` | `Cloudflare Pages` | `https://00ea21ba.…pages.dev` | success |

## Changes

- **Remove `gitHubToken`.** Only the job `environment` records the deployment now. Checked the action source: `pages-deployment-alias-url` is set in `commandOutputParsing.ts` from the wrangler command output, independently of that token, so `environment.url` still resolves.
- **Remove `deployments: write` / `pull-requests: write`.** Added by the same PR, now unused. Runs before #2168 recorded environment deployments fine without them (e.g. deployment `5566918230`, Jul 23).
- **Pass `--branch` explicitly.** Not in the issue, but needed to avoid a regression: the surviving record surfaces the *alias* URL, and `pull_request` checkouts are detached-HEAD, so wrangler was aliasing every PR preview to the shared `head.` subdomain. Each PR now gets its own alias; `workflow_dispatch` on `main` still resolves to `main` → production.

## Tradeoff

Dropping `gitHubToken` also drops wrangler-action's job-summary table (unique per-deployment hash URL + commit). The preview URL still surfaces on the PR via the environment. A small `$GITHUB_STEP_SUMMARY` step could restore that detail if wanted.

## Verification

This PR touches only `.github/workflows/**`, and `Deploy website` is filtered to `docs/**` — so **the workflow will not run here**. Confirming the fix needs a PR that touches `docs/`, or adding this workflow file to its own `paths` filter (the pattern `test-website-a11y.yml` already uses).