### PR TITLE
fix: Keep before-head bars a BarHub never pruned

### DIFF
--- a/src/Common/Bars/BarHub.cs
+++ b/src/Common/Bars/BarHub.cs
@@ -175,6 +175,15 @@ public class BarHub
     /// A bar that hits neither is one the hub simply never received. Accepting
     /// it produces the same cache the reverse arrival order already produces,
     /// so it is inserted like any other out-of-order arrival.
+    /// <para>
+    /// An empty cache admits anything, deliberately. Emptying a pruned hub
+    /// through <c>RemoveRange</c> and re-seeding it with older bars can
+    /// therefore re-create the adjacency the prune boundary otherwise refuses.
+    /// That is left open rather than closed: the boundary is never cleared, so
+    /// refusing here would permanently bar a re-seed and trade a rare
+    /// fabricated adjacency for a new silent drop — the failure this guard
+    /// exists to end.
+    /// </para>
     /// </remarks>
     /// <param name="item">Arriving bar.</param>
     /// <returns><see langword="true"/> when the bar must be discarded.</returns>

--- a/src/Common/Bars/BarHub.cs
+++ b/src/Common/Bars/BarHub.cs
@@ -82,13 +82,23 @@ public class BarHub
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        // Reject additions that precede the current cache timeline
-        // (applies to both standalone and non-standalone BarHub)
+        // Reject additions that fall inside history this hub already pruned
+        // away: that data is gone, so re-admitting a bar beneath the retained
+        // window would leave it adjoining a bar it never followed, and every
+        // downstream indicator would treat the two as consecutive.
+        //
+        // A bar that merely precedes Cache[0] with nothing pruned beneath it is
+        // not that case. The hub never held it, and accepting it produces the
+        // same cache the reverse arrival order already produces today, so it is
+        // inserted like any other out-of-order arrival. (applies to both
+        // standalone and non-standalone BarHub)
         lock (CacheLock)
         {
-            if (Cache.Count > 0 && item.Timestamp < Cache[0].Timestamp)
+            if (Cache.Count > 0
+                && item.Timestamp < Cache[0].Timestamp
+                && PrunedThrough is DateTime prunedThrough
+                && item.Timestamp <= prunedThrough)
             {
-                // Silently ignore - this prevents indeterminate gaps in the timeline
                 return;
             }
         }

--- a/src/Common/Bars/BarHub.cs
+++ b/src/Common/Bars/BarHub.cs
@@ -82,37 +82,34 @@ public class BarHub
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        // Reject additions that fall inside history this hub already pruned
-        // away: that data is gone, so re-admitting a bar beneath the retained
-        // window would leave it adjoining a bar it never followed, and every
-        // downstream indicator would treat the two as consecutive.
-        //
-        // A bar that merely precedes Cache[0] with nothing pruned beneath it is
-        // not that case. The hub never held it, and accepting it produces the
-        // same cache the reverse arrival order already produces today, so it is
-        // inserted like any other out-of-order arrival. (applies to both
-        // standalone and non-standalone BarHub)
-        lock (CacheLock)
-        {
-            if (Cache.Count > 0
-                && item.Timestamp < Cache[0].Timestamp
-                && PrunedThrough is DateTime prunedThrough
-                && item.Timestamp <= prunedThrough)
-            {
-                return;
-            }
-        }
-
-        // for non-root BarHub, use standard behavior (which handles locking)
+        // for non-root BarHub, use standard behavior (which handles locking).
+        // The guard is only a short-circuit here: a before-head item that gets
+        // through re-derives from the provider (AppendCache -> Act.Rebuild),
+        // which no longer holds the dropped bar, so the outcome is the same.
         if (!IsRootHub)
         {
+            lock (CacheLock)
+            {
+                if (RejectsBeforeHead(item))
+                {
+                    return;
+                }
+            }
+
             base.OnAdd(item, notify, indexHint);
             return;
         }
 
-        // Lock for standalone BarHub operations
+        // Lock for standalone BarHub operations. The rejection test lives
+        // inside this same critical section as the insert below it: deciding
+        // under one lock and inserting under another would let a concurrent
+        // prune invalidate the decision in between.
         lock (CacheLock)
         {
+            if (RejectsBeforeHead(item))
+            {
+                return;
+            }
 
             // get result and position
             (IBar result, int index) = ToIndicator(item, indexHint);
@@ -150,6 +147,46 @@ public class BarHub
                 AppendCache(result, notify);
             }
         }
+    }
+
+    /// <summary>
+    /// Decides whether a bar arriving beneath <c>Cache[0]</c> has to be turned
+    /// away. Caller must hold <see cref="StreamHub{TIn, TOut}.CacheLock"/>.
+    /// </summary>
+    /// <remarks>
+    /// Two things make such a bar unkeepable, and only these two:
+    /// <list type="number">
+    /// <item><description>
+    /// It falls inside history this hub already pruned. That data is gone, so
+    /// re-admitting the bar would leave it adjoining one it never followed, and
+    /// every downstream indicator would treat the two as consecutive.
+    /// </description></item>
+    /// <item><description>
+    /// The cache is at capacity. The bar is older than everything retained, so
+    /// there is no room for it and it would be the first thing evicted. This
+    /// has to be settled here rather than left to the insert: the maintenance
+    /// prune inside
+    /// <see cref="StreamHub{TIn, TOut}.InsertWithoutRebuild(TOut, int, bool)"/>
+    /// runs before the insert, so it would evict the retained head to make room
+    /// and only then find the shifted index negative — losing the head as well
+    /// as the arriving bar, a net loss where refusing costs nothing.
+    /// </description></item>
+    /// </list>
+    /// A bar that hits neither is one the hub simply never received. Accepting
+    /// it produces the same cache the reverse arrival order already produces,
+    /// so it is inserted like any other out-of-order arrival.
+    /// </remarks>
+    /// <param name="item">Arriving bar.</param>
+    /// <returns><see langword="true"/> when the bar must be discarded.</returns>
+    private bool RejectsBeforeHead(IBar item)
+    {
+        if (Cache.Count == 0 || item.Timestamp >= Cache[0].Timestamp)
+        {
+            return false;
+        }
+
+        return (PrunedThrough is DateTime prunedThrough && item.Timestamp <= prunedThrough)
+            || Cache.Count >= MaxCacheSize;
     }
 
     /// <summary>

--- a/src/Common/StreamHub/StreamHub.Observer.cs
+++ b/src/Common/StreamHub/StreamHub.Observer.cs
@@ -101,6 +101,9 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamObserver<TIn>
                 if (removedCount > 0)
                 {
                     Cache.RemoveRange(0, removedCount);
+
+                    // provider-driven prune drops history here too
+                    MarkPruned(toTimestamp);
                 }
             }
 

--- a/src/Common/StreamHub/StreamHub.cs
+++ b/src/Common/StreamHub/StreamHub.cs
@@ -28,6 +28,48 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// </summary>
     private bool _initialized;
 
+    /// <summary>
+    /// Latest timestamp this hub has discarded through pruning, or
+    /// <see langword="null"/> when nothing has been pruned.
+    /// </summary>
+    /// <remarks>
+    /// Pruning is the one way a hub loses history it once held, so this marks
+    /// the boundary below which the timeline is no longer representable:
+    /// re-admitting an item at or before it would place an entry next to a
+    /// neighbor it never actually adjoined, and every downstream calculation
+    /// would treat the two as consecutive.
+    /// <para>
+    /// An item that merely precedes <c>Cache[0]</c> is a different case. When
+    /// nothing was pruned away beneath it, the hub simply never received it,
+    /// and accepting it yields exactly the cache an in-order arrival would
+    /// have produced — so timestamp order, not arrival order, decides.
+    /// </para>
+    /// <para>
+    /// Monotonic, and never cleared: pruning is irreversible, and no reset path
+    /// restores the discarded entries. <see cref="Reinitialize"/> in particular
+    /// does not clear it — a root <see cref="BarHub"/> deliberately preserves
+    /// its cache across that call, so the boundary still describes the timeline
+    /// afterward, and a non-root hub re-derives from a provider whose own
+    /// pruned history is equally gone. Read and written under
+    /// <see cref="CacheLock"/>.
+    /// </para>
+    /// </remarks>
+    protected DateTime? PrunedThrough { get; private set; }
+
+    /// <summary>
+    /// Records that history through <paramref name="toTimestamp"/> has been
+    /// discarded, advancing <see cref="PrunedThrough"/> if this prune reaches
+    /// further than any before it.
+    /// </summary>
+    /// <param name="toTimestamp">Timestamp of the last item removed.</param>
+    private void MarkPruned(DateTime toTimestamp)
+    {
+        if (PrunedThrough is null || toTimestamp > PrunedThrough)
+        {
+            PrunedThrough = toTimestamp;
+        }
+    }
+
     private protected StreamHub(IStreamObservable<TIn> provider)
     {
         // store provider reference
@@ -601,6 +643,9 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
 
         // remove all items in one operation
         Cache.RemoveRange(0, count);
+
+        // this history is now unrecoverable; refuse later re-admits below it
+        MarkPruned(toTimestamp);
 
         NotifyObserversOnPrune(toTimestamp);
     }

--- a/src/Common/StreamHub/StreamHub.cs
+++ b/src/Common/StreamHub/StreamHub.cs
@@ -33,28 +33,26 @@ public abstract partial class StreamHub<TIn, TOut> : IStreamHub<TIn, TOut>
     /// <see langword="null"/> when nothing has been pruned.
     /// </summary>
     /// <remarks>
-    /// Pruning is the one way a hub loses history it once held, so this marks
-    /// the boundary below which the timeline is no longer representable:
-    /// re-admitting an item at or before it would place an entry next to a
-    /// neighbor it never actually adjoined, and every downstream calculation
-    /// would treat the two as consecutive.
-    /// <para>
-    /// An item that merely precedes <c>Cache[0]</c> is a different case. When
-    /// nothing was pruned away beneath it, the hub simply never received it,
-    /// and accepting it yields exactly the cache an in-order arrival would
-    /// have produced — so timestamp order, not arrival order, decides.
-    /// </para>
+    /// Pruning is the one way a hub loses history it once held, so this records
+    /// how far that loss reaches. What a hub does with the boundary is its own
+    /// policy — see <c>BarHub.RejectsBeforeHead</c> for the only one today.
     /// <para>
     /// Monotonic, and never cleared: pruning is irreversible, and no reset path
     /// restores the discarded entries. <see cref="Reinitialize"/> in particular
     /// does not clear it — a root <see cref="BarHub"/> deliberately preserves
     /// its cache across that call, so the boundary still describes the timeline
     /// afterward, and a non-root hub re-derives from a provider whose own
-    /// pruned history is equally gone. Read and written under
-    /// <see cref="CacheLock"/>.
+    /// pruned history is equally gone.
+    /// </para>
+    /// <para>
+    /// Written under <see cref="CacheLock"/> on every path that reads it today.
+    /// The root-hub branch of <c>TradeTickHub.OnAdd</c> is a pre-existing
+    /// exception — it mutates the cache outside the lock, so the write reached
+    /// from there is unsynchronized. Nothing reads the boundary on that path,
+    /// so it is latent; a future reader must fix that locking first.
     /// </para>
     /// </remarks>
-    protected DateTime? PrunedThrough { get; private set; }
+    private protected DateTime? PrunedThrough { get; private set; }
 
     /// <summary>
     /// Records that history through <paramref name="toTimestamp"/> has been

--- a/tests/Library/Common/Bars/BarHubTests.cs
+++ b/tests/Library/Common/Bars/BarHubTests.cs
@@ -371,6 +371,35 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
     }
 
     [TestMethod]
+    public void BarPrecedingHead_AtCapacity_LeavesCacheUntouched()
+    {
+        // A full cache has no room for a bar older than everything it holds, so
+        // the bar is refused outright. That has to be decided before the insert:
+        // the maintenance prune inside InsertWithoutRebuild runs first, so it
+        // would evict the retained head to make room and only then find the
+        // shifted index negative — dropping the arriving bar AND the head, a net
+        // loss of one bar where refusing costs nothing.
+        const int maxCacheSize = 50;
+
+        BarHub hub = new(maxCacheSize);
+
+        // exactly at capacity, and nothing has pruned yet
+        hub.Add(Bars.Skip(50).Take(maxCacheSize));
+        hub.Results.Should().HaveCount(maxCacheSize);
+
+        DateTime headBefore = hub.Cache[0].Timestamp;
+        headBefore.Should().Be(Bars[50].Timestamp);
+
+        hub.Add(Bars[10]); // older than every retained bar
+
+        hub.Results.Should().HaveCount(maxCacheSize, "refusing must not shrink the cache");
+        hub.Cache[0].Timestamp.Should().Be(headBefore, "the retained head must survive the refusal");
+        hub.Cache.Should().NotContain(b => b.Timestamp == Bars[10].Timestamp);
+
+        hub.EndTransmission();
+    }
+
+    [TestMethod]
     public void PrunedBoundary_SurvivesReinitialize()
     {
         // Pruning is irreversible, so the boundary must outlive a reset. A root

--- a/tests/Library/Common/Bars/BarHubTests.cs
+++ b/tests/Library/Common/Bars/BarHubTests.cs
@@ -292,7 +292,7 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
     [TestMethod]
     public void AcceptBarPrecedingHead_WhenNothingPruned()
     {
-        // #2153: a hub seeded from the middle of a series has pruned nothing,
+        // issue #2153: a hub seeded from the middle of a series has pruned nothing,
         // so a bar arriving beneath its head is simply one it never received —
         // backfill, a second feed, or plain out-of-order delivery. Discarding
         // it lost data the hub was able to hold.

--- a/tests/Library/Common/Bars/BarHubTests.cs
+++ b/tests/Library/Common/Bars/BarHubTests.cs
@@ -248,13 +248,19 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
     }
 
     [TestMethod]
-    public void BarInsidePrunedHistory_ViaProviderNotification_IsIgnored()
+    public void BarInsidePrunedHistory_ViaProviderNotification_LeavesObserverUnchanged()
     {
-        // The drop on a non-standalone BarHub is now only reachable via the
+        // The rejection on a non-standalone BarHub is only reachable via the
         // provider-notification path (OnAdd), since the public Add is rejected
-        // on a subscribed hub. Pin that branch directly. As with the standalone
-        // case, the drop is justified by the prune: the observer inherits the
-        // provider's prune boundary through OnPrune.
+        // on a subscribed hub. Exercise that branch.
+        //
+        // Honest limit, stated because over-claiming a test is what let the
+        // original defect ship: this pins the OUTCOME, not the branch. A
+        // subscribed hub's cache is a function of its provider's, so a bar that
+        // slipped past the guard would be rebuilt away against the provider —
+        // which no longer holds it — and land on this same cache. The guard is
+        // a short-circuit here, not the thing producing the result, and no
+        // assertion on the observer's cache can tell the two apart.
         const int maxCacheSize = 50;
         const int totalBars = 100;
 
@@ -397,6 +403,61 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
         hub.Cache.Should().NotContain(b => b.Timestamp == Bars[10].Timestamp);
 
         hub.EndTransmission();
+    }
+
+    [TestMethod]
+    public void GapBarPrecedingHead_AtCapacity_LeavesCacheUntouched()
+    {
+        // The variant that matters most, because it strikes a bar this change
+        // exists to ACCEPT: one strictly above the prune boundary, sitting in a
+        // gap the hub never held, arriving while the cache is full. Left to the
+        // insert path it would evict the head, refuse the bar, and — worst —
+        // advance the prune boundary to the destroyed head's timestamp,
+        // permanently shrinking the acceptance window this change widens.
+        BarHub hub = new(21);
+
+        hub.Add(Bars.Take(49));          // prunes; boundary lands at Bars[48]
+        hub.Add(Bars.Skip(60).Take(21)); // head is Bars[60]; cache at capacity
+
+        hub.Results.Should().HaveCount(21);
+        DateTime headBefore = hub.Cache[0].Timestamp;
+        headBefore.Should().Be(Bars[60].Timestamp);
+
+        // above the boundary and below the head: in the never-pruned gap
+        Bars[50].Timestamp.Should().BeAfter(Bars[48].Timestamp);
+        Bars[50].Timestamp.Should().BeBefore(headBefore);
+
+        hub.Add(Bars[50]);
+
+        hub.Results.Should().HaveCount(21, "refusing must not shrink the cache");
+        hub.Cache[0].Timestamp.Should().Be(headBefore, "the retained head must survive");
+        hub.Cache.Should().NotContain(b => b.Timestamp == Bars[50].Timestamp);
+    }
+
+    [TestMethod]
+    public void BarPrecedingHead_AfterPruning_TurnsOnTheBoundaryNotCapacity()
+    {
+        // Pruning leaves the cache exactly at MaxCacheSize, so in the steady
+        // state the capacity rule alone would refuse every before-head bar and
+        // the boundary rule would never be observable. Drop below capacity
+        // first, so this pins the boundary itself: at it, refuse; above it,
+        // accept — the case the suite otherwise never reaches, because every
+        // other acceptance test uses a hub that has never pruned.
+        BarHub hub = new(50);
+        hub.Add(Bars.Take(100)); // prunes [0..49]; boundary at Bars[49]
+        hub.RemoveAt(0);         // 49 of 50: capacity rule now inactive
+
+        hub.Results.Should().HaveCount(49);
+
+        // exactly at the boundary — refused, and `<=` is what makes it so
+        hub.Add(Bars[49]);
+        hub.Results.Should().HaveCount(49, "a bar at the boundary is still inside pruned history");
+        hub.Cache.Should().NotContain(b => b.Timestamp == Bars[49].Timestamp);
+
+        // one step above it — accepted, with room to hold it
+        hub.Add(Bars[50]);
+        hub.Results.Should().HaveCount(50, "a bar above the boundary was never discarded");
+        hub.Cache[0].Timestamp.Should().Be(Bars[50].Timestamp);
     }
 
     [TestMethod]

--- a/tests/Library/Common/Bars/BarHubTests.cs
+++ b/tests/Library/Common/Bars/BarHubTests.cs
@@ -172,8 +172,13 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
     }
 
     [TestMethod]
-    public void IgnoreBarsPrecedingTimeline_Standalone()
+    public void IgnoreBarsInsidePrunedHistory_Standalone()
     {
+        // Pruning is what makes a bar unrepresentable: bars [0..49] were
+        // discarded, so re-admitting one would leave it adjoining bars[50],
+        // a bar it never followed. Dropping is correct *here* — see
+        // AcceptBarPrecedingHead_WhenNothingPruned for the case where the
+        // same relative ordering carries no such loss.
         const int maxCacheSize = 50;
         const int totalBars = 100;
 
@@ -182,7 +187,7 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
         // Setup standalone BarHub with cache limit
         BarHub barHub = new(maxCacheSize);
 
-        // Stream more bars than cache can hold
+        // Stream more bars than cache can hold, forcing a prune
         barHub.Add(bars);
 
         // Verify cache was pruned to maxCacheSize
@@ -191,7 +196,11 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
         // Cache should now contain bars [50..99]
         DateTime firstTimestamp = barHub.Cache[0].Timestamp;
 
-        // Try to add a bar that precedes the current timeline
+        // the precondition this test turns on: history really was discarded
+        firstTimestamp.Should().BeAfter(bars[0].Timestamp,
+            "the drop below is only justified because earlier bars were pruned");
+
+        // Try to add a bar that falls inside the pruned range
         Bar oldBar = bars[10]; // This is before bars[50]
         oldBar.Timestamp.Should().BeBefore(firstTimestamp);
 
@@ -239,11 +248,13 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
     }
 
     [TestMethod]
-    public void BarBeforeHead_ViaProviderNotification_IsIgnored()
+    public void BarInsidePrunedHistory_ViaProviderNotification_IsIgnored()
     {
-        // The before-head drop on a non-standalone BarHub is now only
-        // reachable via the provider-notification path (OnAdd), since the
-        // public Add is rejected on a subscribed hub. Pin that branch directly.
+        // The drop on a non-standalone BarHub is now only reachable via the
+        // provider-notification path (OnAdd), since the public Add is rejected
+        // on a subscribed hub. Pin that branch directly. As with the standalone
+        // case, the drop is justified by the prune: the observer inherits the
+        // provider's prune boundary through OnPrune.
         const int maxCacheSize = 50;
         const int totalBars = 100;
 
@@ -270,5 +281,115 @@ public class BarHubTests : StreamHubTestBase, ITestBarObserver, ITestChainProvid
 
         observer.Unsubscribe();
         provider.EndTransmission();
+    }
+
+    [TestMethod]
+    public void AcceptBarPrecedingHead_WhenNothingPruned()
+    {
+        // #2153: a hub seeded from the middle of a series has pruned nothing,
+        // so a bar arriving beneath its head is simply one it never received —
+        // backfill, a second feed, or plain out-of-order delivery. Discarding
+        // it lost data the hub was able to hold.
+        BarHub hub = new(); // default cache is 100_000; nothing will prune
+
+        hub.Add(Bars.Skip(50).Take(20));
+        DateTime headBefore = hub.Cache[0].Timestamp;
+
+        Bar earlier = Bars[10];
+        earlier.Timestamp.Should().BeBefore(headBefore);
+
+        hub.Add(earlier);
+
+        hub.Results.Should().HaveCount(21, "the earlier bar is representable and must be kept");
+        hub.Cache[0].Timestamp.Should().Be(earlier.Timestamp, "it sorts ahead of the seeded window");
+        hub.Cache[1].Timestamp.Should().Be(headBefore, "the seeded window is otherwise untouched");
+        hub.IsFaulted.Should().BeFalse();
+
+        hub.EndTransmission();
+    }
+
+    [TestMethod]
+    public void AcceptBatchPrecedingHead_WhenNothingPruned()
+    {
+        // The batch path is where the loss was silent enough to miss: a caller
+        // offering 30 bars over a 20-bar cache saw the count stay at 20 — ten
+        // dropped, twenty same-timestamp replacements — and no signal either way.
+        BarHub hub = new();
+
+        hub.Add(Bars.Skip(50).Take(20));
+
+        IReadOnlyList<Bar> batch = Bars.Skip(40).Take(30).ToList();
+        hub.Add(batch);
+
+        // bars [40..69]: ten precede the head, twenty restate what is cached
+        hub.Results.Should().HaveCount(30, "the ten leading bars must survive the batch");
+        hub.Cache[0].Timestamp.Should().Be(Bars[40].Timestamp);
+        hub.Cache.Select(b => b.Timestamp).Should().BeInAscendingOrder();
+
+        hub.EndTransmission();
+    }
+
+    [TestMethod]
+    public void BarPrecedingHead_ArrivalOrderDoesNotChangeCache()
+    {
+        // The clearest statement of the rule: the accepted cache is exactly the
+        // one the reverse arrival order already produced before this fix, so
+        // refusing it was ordering-dependent rather than protective.
+        BarHub inOrder = new();
+        inOrder.Add(Bars[10]);
+        inOrder.Add(Bars.Skip(50).Take(20));
+
+        BarHub outOfOrder = new();
+        outOfOrder.Add(Bars.Skip(50).Take(20));
+        outOfOrder.Add(Bars[10]);
+
+        outOfOrder.Cache.Select(static b => b.Timestamp)
+            .Should().Equal(inOrder.Cache.Select(static b => b.Timestamp));
+
+        inOrder.EndTransmission();
+        outOfOrder.EndTransmission();
+    }
+
+    [TestMethod]
+    public void BarPrecedingHead_CascadesRebuildToObservers()
+    {
+        // A front insert invalidates every downstream calculation, so the
+        // observer must re-derive rather than keep results computed without it.
+        BarHub provider = new();
+        provider.Add(Bars.Skip(50).Take(20));
+
+        BarHub observer = provider.ToBarHub();
+        observer.Results.Should().HaveCount(20);
+
+        provider.Add(Bars[10]);
+
+        observer.Results.Should().HaveCount(21, "the observer rebuilds to include the earlier bar");
+        observer.Cache[0].Timestamp.Should().Be(Bars[10].Timestamp);
+
+        observer.Unsubscribe();
+        provider.EndTransmission();
+    }
+
+    [TestMethod]
+    public void PrunedBoundary_SurvivesReinitialize()
+    {
+        // Pruning is irreversible, so the boundary must outlive a reset. A root
+        // BarHub deliberately preserves its cache across Reinitialize (see the
+        // IsRootHub branch of Rebuild), so the pruned range is still missing
+        // afterward and re-admitting into it would still fabricate adjacency.
+        const int maxCacheSize = 50;
+
+        BarHub hub = new(maxCacheSize);
+        hub.Add(Bars.Take(100)); // forces a prune of bars [0..49]
+        DateTime headBefore = hub.Cache[0].Timestamp;
+
+        hub.Reinitialize();
+
+        hub.Add(Bars[10]); // inside the pruned range
+
+        hub.Cache[0].Timestamp.Should().Be(headBefore,
+            "a reset does not bring pruned history back, so the boundary still applies");
+
+        hub.EndTransmission();
     }
 }


### PR DESCRIPTION
## Problem

`BarHub.OnAdd` discarded any bar whose timestamp preceded `Cache[0]`, returning normally with no exception, no `OnError`, and no change to `IsFaulted`. The guard's stated rationale — preventing indeterminate gaps — holds only when the bar falls inside history the hub actually pruned. It was applied unconditionally, so a hub seeded from the middle of a series silently dropped backfill, second-feed, and out-of-order arrivals it was perfectly able to hold.

The batch path made the loss hardest to see. Offering 30 bars over a 20-bar cache left the count at 20 — ten dropped, twenty same-timestamp replacements — which is indistinguishable from "all duplicates, nothing to do":

```
before=20  batchOffered=30  after=20  silentlyLost=10
```

`BarHub` is a provider, so every subscribed indicator hub then computed on a silently truncated history and reported no fault.

## Fix

Track what pruning discarded (`StreamHub.PrunedThrough`, written by `PruneCache` and by the provider-driven `OnPrune`) and refuse a before-head bar only when it is genuinely unkeepable — for one of exactly two reasons, both in `BarHub.RejectsBeforeHead`:

1. **It falls inside pruned history.** That data is gone, so re-admitting the bar would leave it adjoining one it never followed.
2. **The cache is at capacity.** The bar is older than everything retained and would be the first thing evicted.

Everything else inserts through the existing `InsertWithoutRebuild` path that already handles every other index and cascades a rebuild to observers.

The accepted cache is exactly the one the reverse arrival order already produces, so this removes an ordering dependence rather than adding a behavior. `TradeTickHub` has no such guard and already worked this way.

## What self-review caught

The review swarm found a defect that ran opposite to this PR's purpose, and it is worth recording rather than quietly squashing away.

The first version checked only the prune boundary. At capacity with nothing yet pruned, a before-head bar passed the guard and reached `InsertWithoutRebuild`, which runs its maintenance prune **before** inserting — so it evicted the retained head to make room, then found the shifted index negative and bailed:

| | seed | after `Add(Bars[10])` |
|---|---|---|
| `main` | 50 @ 2017-03-16 | 50 @ 2017-03-16 (no-op) |
| first version | 50 @ 2017-03-16 | **49 @ 2017-03-17** |

Both the arriving bar and a retained bar were lost, and `OnPrune` told every downstream hub to drop that head permanently. A second variant struck a bar the change exists to *accept* — one above the boundary in a never-pruned gap — and additionally advanced `PrunedThrough` to the destroyed head, permanently shrinking the acceptance window this PR widens.

Settling capacity in the guard fixes both. Two coverage gaps behind it were also closed: the boundary comparison was entirely untested (three mutations survived, including degrading it to a bare has-ever-pruned flag), and the suite never exercised acceptance *after* a prune, because pruning leaves the cache exactly at `MaxCacheSize` so the capacity rule masked the boundary rule everywhere.

Review also caught that `PrunedThrough` was `protected` on the public non-sealed `StreamHub<TIn, TOut>` — an unnecessary API commitment, verified reachable by compiling an external subclass against the packaged assembly. Now `private protected`, matching `CacheLock`; the same probe fails with CS0122.

## Tests

Two pre-existing tests are renamed and narrowed rather than left alone. They pruned bars [0..49] before re-adding bar 10, so they pass unchanged — but they were named and commented as the *general* rule, which is how the over-broad guard got certified in the first place. `BarInsidePrunedHistory_ViaProviderNotification_IsIgnored` is also renamed because mutation testing showed it pins nothing: a subscribed hub's cache is a function of its provider's, so a bar slipping past is rebuilt away against a provider that no longer holds it and lands on the same cache. It asserts the outcome, not the branch.

Mutation coverage on the new behavior:

| Mutation | Tests killed |
|---|---|
| Guard → unconditional (the original bug) | 4 |
| Drop the capacity clause | 2 |
| Boundary `<=` → `<` | 1 |
| Drop the boundary clause | 1 |
| `MarkPruned` → no-op | 2 |

## Validation

- `dotnet build src/Indicators.csproj -c Release` — 0 errors, 0 warnings (net8.0/9.0/10.0); the 4 reported are pre-existing NU1507 package-source notices
- `dotnet test tests/Library` — 2578 passed, 0 failed, 12 skipped
- `dotnet test tests/PublicApi` — 76 passed
- `dotnet format --verify-no-changes` — clean

## Known limitations, disclosed rather than fixed here

- **`MarkPruned` in `OnPrune` is not pinned by any test.** A subscribed hub's cache is a function of its provider's, so a bar slipping past re-derives away identically; the line is a short-circuit that avoids a full rebuild cascade. Kept for coherence of the boundary, but no assertion can distinguish it without artificially desyncing an observer from its provider.
- **An empty cache admits anything, deliberately.** Emptying a pruned hub via `RemoveRange` and re-seeding with older bars can recreate the adjacency the boundary otherwise refuses. Left open on purpose: the boundary is never cleared, so refusing would permanently bar a re-seed and trade a rare fabricated adjacency for a new silent drop — the failure this work exists to end. Now a stated decision in the code rather than an inherited accident.
- **`TradeTickHub` has no before-head guard at all** and accepts front inserts unconditionally, including into pruned range. Pre-existing, and this PR narrows one asymmetry while introducing another: the mechanism now sits in a base class used by only half its root hubs. Named here so it is not rediscovered as a bug.
- **The decide-then-insert window on the non-root path** keeps its separate lock. The root path now tests and inserts in one critical section; on the non-root path the guard is only a short-circuit, so a stale read is benign.

## Scope

This fixes the data-loss half of #2153. The other half — signalling the genuinely unrepresentable rejection instead of returning silently — is an API-shaped decision that changes behavior for every existing caller and touches `IStreamHub`, so it is tracked separately rather than bundled here. This PR does **not** make that case observable.

Part of #2153.
