### PR TITLE
docs: Credit Bill Williams for the Fractal

### DIFF
--- a/docs/indicators/fractal.md
+++ b/docs/indicators/fractal.md
@@ -1,11 +1,11 @@
 ---
 title: Williams Fractal
-description: Created by Larry Williams, Fractal is a retrospective price pattern that identifies a central high or low point chevron.
+description: Created by Bill Williams, Fractal is a retrospective price pattern that identifies a central high or low point chevron.
 ---
 
 # Williams Fractal
 
-Created by Larry Williams, [Fractal](https://www.investopedia.com/terms/f/fractal.asp) is a retrospective price pattern that identifies a central high or low point chevron.
+Created by Bill Williams in _Trading Chaos_ (1995), [Fractal](https://www.investopedia.com/terms/f/fractal.asp) is a retrospective price pattern that identifies a central high or low point chevron.
 [[Discuss] &#128172;](https://github.com/facioquo/stock-indicators-dotnet/discussions/255 "Community discussion about this indicator")
 
 <ClientOnly>


### PR DESCRIPTION
## Problem

`docs/indicators/fractal.md` credited the Williams Fractal to **Larry Williams**, in both the frontmatter description and the opening line. The pattern is **Bill Williams'**, from _Trading Chaos_ (1995) — the same author as the Alligator, Gator, and Awesome Oscillator, whose pages already credit him correctly.

Larry Williams is a different trader. He created Williams %R and the Ultimate Oscillator, and `williams-r.md` and `ultimate.md` credit him accurately. The Fractal page was the only one with the names crossed.

The page also cited only Investopedia, where `docs/PRINCIPLES.md` asks indicator pages to link the creator's original publication.

## Fix

Corrects the attribution in both places and names the originating book, while keeping the existing Investopedia link. When the primary source is a book, a secondary reference is what actually lets a reader check the math and read an explanation without buying it, so the two serve different purposes and both belong.

## Note on the emphasis style

The book title uses underscores rather than asterisks. MD049 is left at its `consistent` default in `.markdownlint-cli2.jsonc`, and it resolves the expected style from the first emphasis in the file. An asterisk here would have become the file's reference style and reclassified the underscore emphasis in the `FractalResult` property tables as violations — verified by running `markdownlint-cli2` both ways.

## Verification

`npx markdownlint-cli2 indicators/fractal.md` reports no issues. Content-only change; no source, tests, or navigation touched.

_Found while investigating #2135_