### PR TITLE
docs: State that tied extremes yield no Fractal

### DIFF
--- a/docs/indicators/fractal.md
+++ b/docs/indicators/fractal.md
@@ -45,6 +45,7 @@ IReadOnlyList<FractalResult>
 - It always returns the same number of elements as there are in the historical price bars.
 - It does not return a single incremental indicator value.
 - The first and last `S` periods in `bars` are unable to be calculated since there's not enough prior/following data.
+- Per Williams' definition the middle bar must be strictly beyond both wings, so when two or more bars tie for the extreme value, no fractal is identified.
 
 ::: warning ️🖌️ Repaint warning
 This price pattern uses future bars and will never identify a `fractal` in the last `S` periods of `bars`.  Fractals are retroactively identified.


### PR DESCRIPTION
## Problem

`docs/indicators/fractal.md` documents the evaluation window, the parameters, and the warmup gap, but never states the comparison the indicator actually performs. A reader could not determine from the page what happens when two or more bars tie for the extreme value within the window.

That gap has a cost on record: it took an issue and a proposed patch (#2135) before the answer was stated anywhere.

## Change

One line in the **Response** list, beside the other conditions under which `null` is returned:

> Per Williams' definition the middle bar must be strictly beyond both wings, so when two or more bars tie for the extreme value, no fractal is identified.

It gives the rule and the reason it holds, which is what makes the behavior predictable rather than surprising.

## Scope

Deliberately limited to tie handling — the one case a user actually hit. The page does not enumerate platform variants that depart from Williams' definition, and should not: that list has no natural end and none of it describes what this library computes.

## Verification

`npx markdownlint-cli2 indicators/fractal.md` reports no issues. Documentation only; no behavior change.
